### PR TITLE
Úvodní várka novinek

### DIFF
--- a/content/news.yaml
+++ b/content/news.yaml
@@ -1,8 +1,12 @@
 - type: news
+  date: 2019-09-25-12-00
+  text: Dnes je setkání Česko.Digital
+  url: https://cesko.digital
+- type: news
   date: 2019-09-16-12-00
   text: Michal Bláha byl hostem podcastu Proti proudu. Poslechněte si jeho názory o e-govermentu.
   url: https://cesko.digital
 - type: news
-  date: 2019-09-25-12-00
-  text: Dnes je setkání Česko.Digital
+  date: 2019-09-04-12-00
+  text: Vláda schválila, že veškerý státní SW bude na GitHubu.
   url: https://cesko.digital

--- a/content/news.yaml
+++ b/content/news.yaml
@@ -1,12 +1,31 @@
 - type: news
-  date: 2019-09-25-12-00
-  text: Dnes je setkání Česko.Digital
-  url: https://cesko.digital
+  date: 2019-09-9-12-00
+  url: https://1url.cz/yM5hX
+  text: |
+    Druhé setkání Česko.Digital se uskuteční ve středu 25. září v prostorách
+    STRV v Praze. Srdečně zveme, ať už fyzicky, nebo na livestream!
 - type: news
-  date: 2019-09-16-12-00
-  text: Michal Bláha byl hostem podcastu Proti proudu. Poslechněte si jeho názory o e-govermentu.
-  url: https://cesko.digital
+  date: 2019-09-3-12-00
+  url: https://www.youtube.com/watch?v=inJB-7G-lMQ
+  text: |
+    Jakub Nešetřil byl hostem podcastu Petra Máry. Kromě projektu Česko.Digital
+    zde mluví například o své temné minulosti spojené s pašováním amerických
+    vojenských technologií do komunistického Československa; neváhejte!
 - type: news
-  date: 2019-09-04-12-00
-  text: Vláda schválila, že veškerý státní SW bude na GitHubu.
-  url: https://cesko.digital
+  date: 2019-08-21-12-00
+  url: https://zoom.rba.cz/prednasky/bb-cesko-raj-exekuci-nebo-ne
+  text: |
+    Radek Hábl, autor Mapy exekucí, mluví v Brain&Breakfast o půjčkách a exekucích
+    v ČR. Dobré shrnutí tématu a důvodů, proč Česko.Digital pracuje na projektu
+    Přehled dluhů.
+- type: news
+  date: 2019-05-21-12-00
+  url: https://www.lupa.cz/clanky/jakub-nesetril-cesko-digital-je-moje-nova-zivotni-etapa-skrze-it-chceme-pomoci-spolecnosti/
+  text: |
+    Jakub Nešetřil mluví v rozhovoru pro Lupa.cz o začátcích projektu Česko.Digital.
+- type: news
+  date: 2019-03-13-12-00
+  url: https://protiproudu.net/michal-blaha/
+  text: |
+    Michal Bláha, autor projektu Hlídač státu, byl hostem podcastu Proti proudu,
+    kde mimo jiné mluvil o projektu Hlídač státu a efektivním digitálním Česku.

--- a/content/news/2018/01/28.yaml
+++ b/content/news/2018/01/28.yaml
@@ -1,4 +1,0 @@
-- type: news
-  date: 2019-09-04-12-00
-  text: Vláda schválila, že veškerý státní SW bude na GitHubu.
-  url: https://cesko.digital

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -43,7 +43,7 @@ module.exports = {
       resolve: `gatsby-source-filesystem`,
       options: {
         name: "news",
-        path: `${__dirname}/content/news/`,
+        path: `${__dirname}/content/news.yaml`,
       },
     },
     {

--- a/src/components/news-card/styles.js
+++ b/src/components/news-card/styles.js
@@ -5,12 +5,12 @@ export const Card = styled.div`
   box-shadow: 0px 4px 14px rgba(10, 10, 10, 0.07);
   border-radius: 14px;
   padding: 20px;
-  max-height: 685px;
+  max-height: 740px;
 `;
 
 export const Scrollable = styled.div`
   overflow: scroll;
-  max-height: 600px;
+  max-height: 630px;
 `;
 
 export const Title = styled.h2`

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -56,7 +56,10 @@ export const pageQuery = graphql`
       }
     }
 
-    allNews(sort: { fields: [date], order: DESC }) {
+    allNews(
+      limit: 5
+      sort: { fields: [date], order: DESC }
+    ) {
       edges {
         node {
           url

--- a/src/templates/post/index.jsx
+++ b/src/templates/post/index.jsx
@@ -125,7 +125,10 @@ export const pageQuery = graphql`
       }
     }
 
-    allNews(sort: { fields: [date], order: DESC }) {
+    allNews(
+      limit: 5
+      sort: { fields: [date], order: DESC }
+    ) {
       edges {
         node {
           url


### PR DESCRIPTION
Součást #22. Sestěhoval jsem novinky do jednoho souboru a přidal úvodní várku obsahu. V praxi se napravo neobjeví všechny – je to záměr?

Ještě by podle mě stálo za úvahu je nějak lehce přestylovat, teď to vypadá trochu neohrabaně (hodně podtrhávaného textu). Zvážil bych, jestli neodstranit podtržení a neudělat klikací celý ten blok od jedné dělicí čáry po druhou. To samozřejmě vůbec nehoří, v případě zájmu si můžem poznačit jízdenku bokem a vyřešit později.