### PR TITLE
[rss] Změna isPermanent na "true"

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -132,7 +132,6 @@ module.exports = {
                 title: edge.node.frontmatter.title,
                 description: edge.node.frontmatter.description,
                 url: rssMetadata.site_url + edge.node.fields.slug,
-                guid: rssMetadata.site_url + edge.node.fields.slug,
                 custom_elements: [
                   { 'content:encoded': edge.node.html },
                   { author: `${edge.node.frontmatter.author.name} &lt;${edge.node.frontmatter.author.email}&gt;` },


### PR DESCRIPTION
RSS.js (závislost `gatsby-plugin-feed`u) generuje atribut `isPermanent=false`, pokud je hodnota `GUID` nastavená explicitně: https://github.com/dylang/node-rss/blob/master/lib/index.js#L69

Pokud je nastavena jen URL, element `GUID` je vygenerovaný s parametrem `isPermanent=true`. Podle kódu RSS.js se `isPermanent` nedá vypnout 🤷‍♂️

Closes #28