### PR TITLE
[post template] Remove Bio & Twitter attributes

### DIFF
--- a/content/authors.yaml
+++ b/content/authors.yaml
@@ -2,8 +2,6 @@
   id: zoul
   name: Tomáš Znamenáček
   email: tomas.znamenacek@gmail.com
-  bio: ""
-  twitter: ""
 - type: authors
   id: radja
   name: Radka Horáková

--- a/src/templates/post/index.jsx
+++ b/src/templates/post/index.jsx
@@ -84,9 +84,6 @@ export const pageQuery = graphql`
         author {
           id
           name
-          bio
-          twitter
-            email
         }
       }
       fields {

--- a/src/templates/post/index.jsx
+++ b/src/templates/post/index.jsx
@@ -84,6 +84,7 @@ export const pageQuery = graphql`
         author {
           id
           name
+          email
         }
       }
       fields {


### PR DESCRIPTION
Odstraňuje Bio a Twitter atributy z postu, jelikož nejsou používané a jejich odebrání od autorů rozbije build.

Bohužel, dneska není možnost nastavit frontmatter atributy jako volitelné.
Pokoušel se o to [plugin] (https://www.npmjs.com/package/gatsby-remark-frontmatter-defaults), ale už neexistuje na GH.

Closes #26 