### PR TITLE
Stěhování obrázků z blogu na náš server

### DIFF
--- a/content/posts/2019/2019-08-10-novinky.md
+++ b/content/posts/2019/2019-08-10-novinky.md
@@ -4,7 +4,7 @@ date: 2019-08-10-12-00
 author: radja
 category: blog
 slug: novinky
-cover: https://i.imgur.com/N4oQR8n.jpg
+cover: https://data.cesko.digital/img/6a9b4eac.jpg
 tags:
     - newsletter
 description: "Léto je v plném proudu, ale my nezahálíme. V uplynulém měsíci jsme se zaměřili na zpřehlednění toho, jak bude naše komunita fungovat, prošli jsme desítky navržených veřejně prospěšných projektů – velmi za ně děkujeme – a absolvovali jsme celou řadu schůzek, které nám pomohou posunout se významně dál. A samozřejmě, týmy z vašich řad nadále pracují na vybraných projektech."

--- a/content/posts/2019/2019-09-10-novinky.md
+++ b/content/posts/2019/2019-09-10-novinky.md
@@ -4,7 +4,7 @@ date: 2019-09-10-12-00
 author: radja
 category: blog
 slug: novinky
-cover: https://i.imgur.com/M7dcSAq.jpg
+cover: https://data.cesko.digital/img/e57050e1.jpg
 tags:
     - newsletter
 description: "Zdravíme vás a než vám přiblížíme, co je u nás za srpen nového, srdečně vás hned v úvodu zveme na Česko.Digital MEETUP #2, který se uskuteční ve středu 25. 9. od 18:00 v parádních prostorách týmu STRV v Praze (děkujeme za podporu!). Prosíme, registrujte se, ať na vás zbyde nejen drink, ale i něco dobrého k snědku."

--- a/content/posts/2019/2019-09-20-rozhovor-nesetril.md
+++ b/content/posts/2019/2019-09-20-rozhovor-nesetril.md
@@ -5,7 +5,7 @@ author: zoul
 category: blog
 slug: rozhovor-nesetril
 description: "Jakub Nešetřil vybudoval a v roce 2017 prodal úspěšnou technologickou firmu Apiary. Místo aby si vydělané peníze užíval někde na pláži, jak se na milionáře sluší a patří, rozhodl se, že si bude život dál komplikovat – a to tím, že se pomocí digitálních technologií bude snažit zjednodušit životy ostatních. S několika společníky založil organizaci Česko.Digital, která má za cíl usnadňovat spolupráci státu, nevládních organizací a dobrovolníků z IT komunity. A jelikož dnes digitální technologie tvoří velkou část pojmu „stát“, dá se tento cíl shrnout i stručněji: lepší Česko pro všechny."
-cover: https://firebasestorage.googleapis.com/v0/b/blog-cesko-digital.appspot.com/o/2019%2F09%2Frozhovor-s-jakubem-nesetrilem%2FDSCF0011.jpg?alt=media&token=8f4f25fe-2165-4401-a355-72d1670a38c1
+cover: https://data.cesko.digital/img/054e660d.jpg
 ---
 
 **Česko.Digital má za sebou řekněme půlrok existence. Podle agilního vývoje softwaru existuje jediné skutečné měřítko pokroku, a tím je hotová práce, hodnota pro koncové uživatele. Co se tímto pohledem za onoho půl roku podařilo?**

--- a/content/posts/2019/2019-10-01-zaznam-setkani.md
+++ b/content/posts/2019/2019-10-01-zaznam-setkani.md
@@ -5,7 +5,7 @@ author: radja
 category: blog
 slug: zaznam-setkani
 description: "Ve středu 25. 9. se v prostorách STRV sešlo na 120 členů a podporovatelů komunity Česko.Digital. Pokud jste se nestihli zúčastnit osobně ani na live streamu, nabízíme záznam všech vystoupení."
-cover: https://i.imgur.com/ObMcG33.jpg
+cover: https://data.cesko.digital/img/02711d51.jpg
 ---
 
 Na druhém setkání komunity zazněly z úst Jakuba Nešetřila novinky z Česko.Digital. Co se za uplynulé týdny podařilo, jak se můžou dobrovolníci, neziskovky i státní sféra zapojit, to vše se dozvíte z Jakubovy prezentace.

--- a/content/posts/2019/2019-10-22-novinky.md
+++ b/content/posts/2019/2019-10-22-novinky.md
@@ -1,6 +1,6 @@
 ---
 title: "Novinky za září 2019: První HackDay | Jak to u nás chodí | Stav současných projektů"
-cover: https://i.imgur.com/BpXBuZj.jpg
+cover: https://data.cesko.digital/img/703f1ca6.jpg
 author: radja
 date: 2019-10-22-09-00
 category: blog

--- a/content/posts/2019/2019-11-13-nove-posily.md
+++ b/content/posts/2019/2019-11-13-nove-posily.md
@@ -1,6 +1,6 @@
 ---
 title: Nové posily v týmu
-cover: https://i.imgur.com/3yD3DlB.jpg
+cover: https://data.cesko.digital/img/fb31efbe.jpg
 author: jakub
 date: 2019-11-13-08-00
 category: blog

--- a/content/posts/2019/2019-11-13-novinky.md
+++ b/content/posts/2019/2019-11-13-novinky.md
@@ -1,6 +1,6 @@
 ---
 title: "Novinky za říjen 2019: HackDay 28.11. | Nové posily | Stav současných projektů"
-cover: https://firebasestorage.googleapis.com/v0/b/blog-cesko-digital.appspot.com/o/2019%2F2019-11-13-novinky_cover.png?alt=media&token=b40103f6-5de6-4273-a923-9b07423b5c1a
+cover: https://data.cesko.digital/img/28dad6c3.jpg
 author: jakub
 date: 2019-11-13-07-30
 category: blog
@@ -23,7 +23,7 @@ Profesionalizace organizačního týmu Česko.Digital je důležitá, abychom ud
 
 Zajímá vás, proč se Eva a Radka do komunity zapojily, na co se chtějí zaměřit a co je v životě baví? Přečtěte si víc v [rozhovoru](/2019/11/nove-posily).
 
-![Eva Pavlíková a Radka Horáková](https://i.imgur.com/3yD3DlB.jpg)  
+![Eva Pavlíková a Radka Horáková](https://data.cesko.digital/img/fb31efbe.jpg)
 
 ### Rozhovor o cestě Code4Romania
 

--- a/content/posts/2019/2019-11-7-rozhovor-vereha.md
+++ b/content/posts/2019/2019-11-7-rozhovor-vereha.md
@@ -1,6 +1,6 @@
 ---
 title: Nahradili jsme pero, papír a šestiměsíční proces něčím, co funguje v reálném čase
-cover: https://i.imgur.com/Z6ODyiG.jpg
+cover: https://data.cesko.digital/img/559b7e82.jpg
 author: zoul
 date: 2019-11-07-08-00
 category: blog
@@ -53,7 +53,7 @@ To, že jsme nikdy nebyli militantní, nám umožnilo navázat se státní sprá
 
 Naše důvěryhodnost pramení také z toho, že máme jednoduše měřitelné výsledky – počty návštěvníků, dopad na společnost, to jsou jasně měřitelné a srozumitelné ukazatele. Což je ostatně důvod, proč jsem se ke Code for Romania přidala já. Byla to pro mě první možnost, jak se coby UX designér nějak zapojit do veřejného sektoru. První místo, kde mohl jako dobrovolník pracovat i devops inženýr. Kdybych měla sázet stromy, nedopadlo by to dobře, vůbec to s rostlinami neumím. Ale co umím, je navrhnout nástroj, který veřejnosti vysvětlí, jak je důležité sázet stromy – a sehnat lidi, kteří to pak udělají.
 
-![Olivia Vereha](https://i.imgur.com/4z9XNpV.jpg)
+![Olivia Vereha](https://data.cesko.digital/img/cd29d538.jpg)
 
 ## Hodně pokusů, hodně omylů
 

--- a/content/posts/2019/2019-11-7-vereha-interview.md
+++ b/content/posts/2019/2019-11-7-vereha-interview.md
@@ -1,6 +1,6 @@
 ---
 title: We have replaced pen & paper and a six months long process with something that happens in real time
-cover: https://i.imgur.com/Z6ODyiG.jpg
+cover: https://data.cesko.digital/img/559b7e82.jpg
 author: zoul
 date: 2019-11-07-08-00
 category: blog
@@ -53,7 +53,7 @@ The fact that we were never militant also helped us in securing a good relations
 
 What also got us credibility is that they understand what comes out of this. We make it simple, easy to measure – number of visitors, what kind of impact was achieved, it’s all very numeric and very simple to understand. This was also the reason I have joined Code for Romania when I first heard about it – it was the first place where my skills as a UX designer were useful in the public sector. It was the first time a devops engineer finally found a place to volunteer. If you’re going to make me plant a tree, that tree is going to die. I’m awful with plants. But I can design a tool that’s going to increase awareness on why you should plant trees and get the people who actually can do it.
 
-![Olivia Vereha](https://i.imgur.com/4z9XNpV.jpg)
+![Olivia Vereha](https://data.cesko.digital/img/cd29d538.jpg)
 
 ## Lots of trial and error
 

--- a/content/posts/2019/2019-12-17-hackday.md
+++ b/content/posts/2019/2019-12-17-hackday.md
@@ -1,6 +1,6 @@
 ---
 title: První hackday Česko.Digital
-cover: https://i.imgur.com/nHw4QPG.jpg
+cover: https://data.cesko.digital/img/52ea0205.jpg
 author: zoul
 date: 2019-12-17-19-20
 category: blog

--- a/content/posts/2019/2019-12-19-novinky.md
+++ b/content/posts/2019/2019-12-19-novinky.md
@@ -1,6 +1,6 @@
 ---
 title: "Novinky za listopad 2019: Tech ve službách lidu | Kam nás posunul hackday #1 | Stav současných projektů"
-cover: https://firebasestorage.googleapis.com/v0/b/blog-cesko-digital.appspot.com/o/2019%2F2019-12-19-novinky_cover.jpg?alt=media&token=b60a1670-f1a4-4c5c-96f2-c6902245574f
+cover: https://data.cesko.digital/img/21f98176.jpg
 author: radja
 date: 2019-12-19-18-30
 category: blog

--- a/content/posts/2020/2020-01-13-novinky.md
+++ b/content/posts/2020/2020-01-13-novinky.md
@@ -1,6 +1,6 @@
 ---
 title: "Novinky za prosinec 2019: Hledáme posily | Seznamovací setkání | Stávající projekty"
-cover: https://firebasestorage.googleapis.com/v0/b/blog-cesko-digital.appspot.com/o/2020%2F2020-01-13-novinky_cover.jpg?alt=media&token=b0d08a7d-caec-4e15-863e-a93991fb32a4
+cover: https://data.cesko.digital/img/544caafa.jpg
 author: radja
 date: 2020-01-13-18-30
 category: blog

--- a/content/posts/2020/2020-02-19-novinky.md
+++ b/content/posts/2020/2020-02-19-novinky.md
@@ -1,6 +1,6 @@
 ---
 title: "Novinky za leden 2020: Nový projekt Šablony výběrových řízení | Debata k modernímu řízení IT zakázek | Posily v týmu"
-cover: https://i.imgur.com/rlXysli.jpg
+cover: https://data.cesko.digital/img/8f1bf1ff.jpg
 author: radja
 date: 2020-02-19-10-03
 category: blog

--- a/content/posts/2020/2020-1-30-prirucka.md
+++ b/content/posts/2020/2020-1-30-prirucka.md
@@ -1,6 +1,6 @@
 ---
 title: Příručka řízení státních IT projektů
-cover: https://i.imgur.com/25W4E94.jpg
+cover: https://data.cesko.digital/img/160e9654.jpg
 author: zoul
 date: 2020-01-30-11-10
 category: blog

--- a/content/posts/2020/2020-2-21-cityvizor-letak.md
+++ b/content/posts/2020/2020-2-21-cityvizor-letak.md
@@ -1,6 +1,6 @@
 ---
 title: "Cityvizor do každé obce"
-cover: https://d1auyf4nfs2kod.cloudfront.net/img/0f118dbf.jpg
+cover: https://data.cesko.digital/img/0f118dbf.jpg
 author: eva
 date: 2020-02-21-16-16
 category: blog

--- a/content/posts/2020/2020-2-6-debata.md
+++ b/content/posts/2020/2020-2-6-debata.md
@@ -1,6 +1,6 @@
 ---
 title: Jak lépe řídit státní IT zakázky? Záznam živé debaty
-cover: https://i.imgur.com/9zLrRkO.jpg
+cover: https://data.cesko.digital/img/ef0dc65e.jpg
 author: zoul
 date: 2020-02-6-8-30
 category: blog
@@ -23,7 +23,7 @@ Jedním „řešením“ problému používaným například na Ministerstvu fin
 
 Jakub Nešetřil pak diskuzi vrátil ještě ke dvěma podstatným faktorům, které kromě platu určují atraktivitu zaměstnavatele: kvalitě týmu a vědomí smysluplné práce, která je dnes nedostatkovým zbožím. Pokud stát nabídne zaměstnancům volnost, kvalitní kolegy a možnost skutečně ovlivnit fungování společnosti, může podle něj i s nižšími platy obstát v konkurenci ostatních zaměstnavatelů. Což potvrdil i Tomáš Vondráček, podle kterého jsou vnitřně naplňující projekty v komerční sféře spíše výjimkou – a přitom na hackathon dálničních známek (tedy výběr daní!) není problém sehnat obratem ruky desítky dobrovolníků.
 
-![Jakub Nešetřil](https://i.imgur.com/OmgxZNf.jpg)
+![Jakub Nešetřil](https://data.cesko.digital/img/2a6c8d98.jpg)
 
 ## Strašidlo jménem NKÚ
 
@@ -35,7 +35,7 @@ Základní problém na straně veřejné správy shrnul Miloslav Marčan z MPO: 
 
 Jednoduché řešení v rámci stávající legislativy nabídl Michal Bláha: „Nesoutěžte produkt, soutěžte služby. Nesoutěžte to, že vám někdo dodá produkt XY, ale zaplaťte si programátory, kteří vám postupně budou dodávat, co potřebujete.“ Tím jsme se ale dostali zpět k problému s nedostatkem lidí, kteří by takový projekt ve státní správě uřídili. „Pojďme se tomu nevyhýbat,“ shrnul debatu Jakub Nešetřil. „Uspořádejme s Ministerstvem pro místní rozvoj diskuzi o veřejných zakázkách.“ Jeho výzvu přijal Vladimír Dzurilla, který slíbil konferenci svolat.
 
-![Debata v Paralelní Polis](https://i.imgur.com/iq8tEjx.jpg)
+![Debata v Paralelní Polis](https://data.cesko.digital/img/a82ee435.jpg)
 
 ## Centrální IT úřad
 
@@ -45,7 +45,7 @@ Tuto situaci by mohl výrazně změnit centrální IT úřad, který má podle V
 
 S příklady dobré praxe by podle Jakuba Nešetřila chtělo pomoci i Česko.Digital: „Tento měsíc vykopáváme projekt vzorových šablon pro výběrová řízení na dodavatele i lidi. Nejsme experti na státní správu ani výběrová řízení, ale jsme experti na technologie a můžeme státu pomoci najít kvalitní UX odborníky, technické analytiky a podobné profese, s jejichž najímáním má státní správa malé zkušenosti. Budeme moc rádi, když se nám zástupci státní správy ozvou se svými požadavky.“
 
-![Debata v Paralelní Polis](https://i.imgur.com/30evkSS.jpg)
+![Debata v Paralelní Polis](https://data.cesko.digital/img/a25739fd.jpg)
 
 ## Jak dál?
 


### PR DESCRIPTION
Konečně nám naskočil server pro data (data.cesko.digital), tak jsem tam přestěhoval všecky obrázky. Kvůli kešování jsou veškeré obrázky pojmenované prefixem z SHA256 jejich obsahu:

```
shasum -a 256 someimage.jpg | cut -c 1-8
```

Díky tomu můžeme nastavit kešovací hlavičky na prakticky nekonečnou živnotnost a klienti se nemusí vůbec ptát, jestli se obrázek na serveru nezměnil – kdyby jo, změní se jeho URL.

Doufám, že jsem přestěhoval všechno – zkoušel jsem grepnout adresář `content/` na řetězce `imgur` a `firebase` a nenašel nic, tak snad dobrý. Ještě něco je potřeba vyřešit?

PS. Github, this fixes #7.