### PR TITLE
Odstranění levého odsazení v odrážkových a číslovaných seznamech

### DIFF
--- a/src/components/post/styles.js
+++ b/src/components/post/styles.js
@@ -116,6 +116,10 @@ export const Content = styled.div`
     line-height: 26px;
   }
 
+  ul, ol {
+    padding-left: 1.2em;
+  }
+
   img {
     border-radius: 10px;
     max-width: 100%;


### PR DESCRIPTION
Levé odsazení v seznamech je zbytečné a žere nám místo na úzkých displejích. Matěji, strkám to na správný místo a je to dobré řešení, pokud jde o CSS? Díky!