### PR TITLE
Nastavení Netlify CMS pro správu tiskových zpráv

### DIFF
--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -60,3 +60,49 @@ collections:
       - label: "Text"
         name: "body"
         widget: "markdown"
+  - label: "Press Releases"
+    label_singular: "Press Release"
+    name: "press"
+    folder: "content/press"
+    path: '{{year}}-{{month}}-{{day}}-{{slug}}'
+    create: true
+    slug: '{{fields.slug}}'
+    fields:
+      - label: "Title"
+        name: "title"
+        widget: "string"
+        required: true
+      - label: "Author"
+        name: "author"
+        widget: "select"
+        options: ["zoul", "radja", "jakub", "eva", "vjirovsky", "jana", "marketaz",
+          "teryii", "urbant", "hrudka", "katka", "dana", "zaneta", "iva", "bara",
+          "alena", "lukas", "tt", "kaku", "martina", "gabi", "lenkab", "rona",
+          "lvanous", "horm", "zu", "lukas.n", "tereza.lattova", "jan.hobler", "marketa.horakova"]
+        required: true
+      - label: "Cover"
+        name: "cover"
+        widget: "string"
+        required: true
+      - label: "Date"
+        name: "date"
+        widget: "datetime"
+        format: "YYYY-MM-DD-hh-mm"
+        required: true
+      - label: "Slug"
+        name: "slug"
+        widget: "string"
+        required: true
+        slug: '{{title}}'
+      - label: "Description"
+        name: "description"
+        widget: "string"
+        required: true
+      - label: "Language"
+        name: "lang"
+        widget: "select"
+        options: ["cs", "en"]
+        default: "cs"
+      - label: "Text"
+        name: "body"
+        widget: "markdown"


### PR DESCRIPTION
Přidal jsem do Netlify CMS kolekci „Press Releases“, díky které by mělo jít teď administrovat kromě blog postů i tiskové zprávy.