### PR TITLE
Zjednodušení hlavního menu

### DIFF
--- a/components/navigation-bar.tsx
+++ b/components/navigation-bar.tsx
@@ -1,19 +1,11 @@
-const navigationItems = [
-  {
-    url: "https://cesko.digital/projects",
-    name: "Projekty",
-  },
-  {
-    name: "Blog",
-    url: "/",
-  },
-  {
-    url: "https://www.darujme.cz/projekt/1203553",
-    name: "Přispět",
-  },
-];
+import {Router, withRouter} from 'next/router';
+import Link from 'next/link'
 
-const NavigationBar: React.FC = () => (
+interface Props {
+  router: Router;
+}
+
+const NavigationBar: React.FC<Props> = (props) => (
   <div className="header-wrapper">
     <div className="navigation-bar">
       <div>
@@ -21,15 +13,14 @@ const NavigationBar: React.FC = () => (
       </div>
       <div>
         <div className="toolbar-links">
-          {navigationItems.map((item, index) => (
-            <a className="toolbar-link" key={index} href={item.url}>
-              {item.name}
-            </a>
-          ))}
+          {props.router.asPath !== '/' &&
+          <Link href="/">
+            <a className="toolbar-link">← Zpět na všechny články</a>
+          </Link>}
         </div>
       </div>
     </div>
   </div>
 );
 
-export default NavigationBar;
+export default withRouter(NavigationBar);

--- a/global.css
+++ b/global.css
@@ -82,7 +82,7 @@ body {
 .navigation-bar {
   display: flex;
   width: 100%;
-  flex-direction: row;
+  flex-direction: row-reverse;
   justify-content: space-between;
   align-items: center;
   margin-right: 20px;
@@ -97,7 +97,7 @@ body {
   background-size: contain;
   padding: 0 !important;
   color: #1a2c29;
-  margin: 32px 20px 28px 0;
+  margin: 32px 5px 28px 20px;
   /*
   &__inner {
     display: none;
@@ -127,6 +127,9 @@ body {
   overflow: hidden;
   white-space: nowrap;
   width: min-content;
+}
+.toolbar-link:first-child {
+  margin-left: 5px;
 }
 
 .toolbar-link:hover {
@@ -539,11 +542,15 @@ ol {
 
   .toolbar-links {
     justify-content: flex-start;
-    border-bottom: #1d1f21 solid 1px;
   }
 
   .toolbar-link {
-    margin: 0 25px 10px 0;
+    margin: 0 25px 25px 0;
+    text-decoration: none;
+  }
+
+  .toolbar-link:hover {
+    text-decoration: underline;
   }
 
   .main-post {


### PR DESCRIPTION
Tento patch zjednodušuje hlavní menu, a usnadňuje navigaci na blogu: logo č.d je přesunuto vpravo, a vede na hlavní web (tak jako v předchozí verzi), a na stránce článku vlevo zobrazujeme odkaz na hlavní stránku blogu.

<img width="1304" alt="image" src="https://user-images.githubusercontent.com/4790/153715123-7eeed5f3-ceb8-486d-8e04-b673b9023c51.png">
