### PR TITLE
Add basic Playwright infrastructure & endpoint tests

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,0 +1,27 @@
+name: E2E Tests
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+jobs:
+  test:
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - name: Install dependencies
+        run: yarn install
+      - name: Install Playwright Browsers
+        run: npx playwright install --with-deps
+      - name: Run Playwright tests
+        run: npx playwright test
+      - uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 30

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "unified": "^10.1.1"
   },
   "devDependencies": {
+    "@playwright/test": "^1.30.0",
     "@types/jest": "^27.4.0",
     "@types/js-yaml": "^4.0.5",
     "@types/marked": "^4.0.2",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from "@playwright/test";
+
+export default defineConfig({
+  webServer: {
+    command: "yarn dev",
+    url: "http://localhost:3000/",
+    timeout: 120 * 1000,
+    reuseExistingServer: !process.env.CI,
+  },
+  use: {
+    baseURL: "http://localhost:3000/",
+    browserName: "webkit",
+  },
+  testMatch: /.*\.e2e\.ts/,
+});

--- a/tests/feeds.e2e.ts
+++ b/tests/feeds.e2e.ts
@@ -1,0 +1,12 @@
+import { test, expect } from "@playwright/test";
+
+test("Article endpoint works", async ({ page }) => {
+  const response = await page.request.get("/api/articles");
+  await expect(response).toBeOK();
+  expect(await response.json()).toBeTruthy();
+});
+
+test("RSS feed endpoint works", async ({ page }) => {
+  const response = await page.request.get("/api/feed");
+  await expect(response).toBeOK();
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -637,6 +637,14 @@
     tiny-glob "^0.2.9"
     tslib "^2.4.0"
 
+"@playwright/test@^1.30.0":
+  version "1.30.0"
+  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.30.0.tgz#8c0c4930ff2c7be7b3ec3fd434b2a3b4465ed7cb"
+  integrity sha512-SVxkQw1xvn/Wk/EvBnqWIq6NLo1AppwbYOjNLmyU0R1RoQ3rLEBtmjTnElcnz8VEtn11fptj1ECxK0tgURhajw==
+  dependencies:
+    "@types/node" "*"
+    playwright-core "1.30.0"
+
 "@rushstack/eslint-patch@^1.1.3":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@rushstack/eslint-patch/-/eslint-patch-1.2.0.tgz#8be36a1f66f3265389e90b5f9c9962146758f728"
@@ -4561,6 +4569,11 @@ pkg-dir@^4.2.0:
   integrity sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==
   dependencies:
     find-up "^4.0.0"
+
+playwright-core@1.30.0:
+  version "1.30.0"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.30.0.tgz#de987cea2e86669e3b85732d230c277771873285"
+  integrity sha512-7AnRmTCf+GVYhHbLJsGUtskWTE33SwMZkybJ0v6rqR1boxq2x36U7p1vDRV7HO2IwTZgmycracLxPEJI49wu4g==
 
 postcss@8.4.14:
   version "8.4.14"


### PR DESCRIPTION
Vyrobil jsem nepříjemný přehmat s nekonečným cyklem mezi API endpointy, a ex post mě napadlo, že se tomu dalo předejít aspoň základním testem endpointů, tak ho přidávám.